### PR TITLE
fix: remove hardcoded indentation settings from ftplugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ test:
 	@nvim --headless --noplugin --clean -c "luafile tests/completion_test.lua"
 	@nvim --headless --noplugin --clean -c "luafile tests/autofill_test.lua"
 	@nvim --headless --noplugin --clean -c "luafile tests/indentation_test.lua"
+	@nvim --headless --noplugin --clean -c "luafile tests/formatter_test.lua"
 	@echo "Running Python tests..."
 	@python3 -m unittest tests/beancheck_test.py || echo "Python unittest not available or tests failed. Install with: pip install beancount"
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test:
 	@nvim --headless --noplugin --clean -c "luafile tests/completion_blink_test.lua"
 	@nvim --headless --noplugin --clean -c "luafile tests/completion_test.lua"
 	@nvim --headless --noplugin --clean -c "luafile tests/autofill_test.lua"
+	@nvim --headless --noplugin --clean -c "luafile tests/indentation_test.lua"
 	@echo "Running Python tests..."
 	@python3 -m unittest tests/beancheck_test.py || echo "Python unittest not available or tests failed. Install with: pip install beancount"
 

--- a/ftplugin/beancount.lua
+++ b/ftplugin/beancount.lua
@@ -10,12 +10,6 @@ vim.b.did_ftplugin = 1
 vim.bo.commentstring = ";; %s"
 vim.bo.comments = "b:;;"
 
--- Set indentation options
-vim.bo.expandtab = true
-vim.bo.shiftwidth = 4
-vim.bo.tabstop = 4
-vim.bo.softtabstop = 4
-
 -- Set folding options
 vim.wo.foldmethod = "expr"
 vim.wo.foldexpr = "v:lua.require('beancount.fold').foldexpr()"
@@ -63,4 +57,4 @@ end
 require("beancount").setup_buffer()
 
 -- Set the undo point for the plugin loading
-vim.b.undo_ftplugin = "setl cms< com< fo< fdm< fde< et< sw< ts< sts<"
+vim.b.undo_ftplugin = "setl cms< com< fo< fdm< fde<"

--- a/lua/beancount/formatter.lua
+++ b/lua/beancount/formatter.lua
@@ -146,11 +146,11 @@ M.align_amount = function(line_num)
 end
 
 M.indent_posting_line = function(line_num)
-  local tab_size = vim.bo.tabstop or 4
-  local indent = string.rep(" ", tab_size)
+  local indent_size = vim.fn.shiftwidth()
+  local indent = string.rep(" ", indent_size)
 
   vim.fn.setline(line_num, indent)
-  vim.fn.cursor(line_num, tab_size + 1)
+  vim.fn.cursor(line_num, indent_size + 1)
 end
 
 -- Format a complete transaction block

--- a/lua/beancount/formatter.lua
+++ b/lua/beancount/formatter.lua
@@ -146,11 +146,15 @@ M.align_amount = function(line_num)
 end
 
 M.indent_posting_line = function(line_num)
-  local indent_size = vim.fn.shiftwidth()
-  local indent = string.rep(" ", indent_size)
+  local indent
+  if vim.bo.expandtab then
+    indent = string.rep(" ", vim.fn.shiftwidth())
+  else
+    indent = "\t"
+  end
 
   vim.fn.setline(line_num, indent)
-  vim.fn.cursor(line_num, indent_size + 1)
+  vim.fn.cursor(line_num, #indent + 1)
 end
 
 -- Format a complete transaction block

--- a/tests/formatter_test.lua
+++ b/tests/formatter_test.lua
@@ -1,0 +1,81 @@
+-- Tests for beancount formatter module
+-- Verifies indent_posting_line respects user expandtab setting
+
+---@diagnostic disable-next-line: redundant-parameter
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+print("Running formatter tests...")
+
+local function test_assert(condition, message)
+  if not condition then
+    error("Test failed: " .. (message or "assertion failed"))
+  end
+end
+
+local tests_run = 0
+local tests_passed = 0
+
+local function run_test(name, test_fn)
+  tests_run = tests_run + 1
+  local success, err = pcall(test_fn)
+  if success then
+    tests_passed = tests_passed + 1
+    print("  ✓ " .. name)
+  else
+    print("  ✗ " .. name .. ": " .. tostring(err))
+  end
+end
+
+local formatter = require("beancount.formatter")
+
+-- Verify indent_posting_line uses tab when expandtab=false
+run_test("indent_posting_line uses tab when expandtab=false", function()
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(bufnr)
+  vim.api.nvim_buf_set_option(bufnr, "expandtab", false)
+  vim.api.nvim_buf_set_option(bufnr, "shiftwidth", 4)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "" })
+  formatter.indent_posting_line(1)
+  local line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+  test_assert(line == "\t", "expected tab character, got: " .. vim.inspect(line))
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Verify indent_posting_line uses spaces when expandtab=true
+run_test("indent_posting_line uses spaces when expandtab=true", function()
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(bufnr)
+  vim.api.nvim_buf_set_option(bufnr, "expandtab", true)
+  vim.api.nvim_buf_set_option(bufnr, "shiftwidth", 4)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "" })
+  formatter.indent_posting_line(1)
+  local line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+  test_assert(line == "    ", "expected 4 spaces, got: " .. vim.inspect(line))
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Verify indent_posting_line uses spaces with shiftwidth=2 when expandtab=true
+run_test("indent_posting_line uses 2 spaces when shiftwidth=2 and expandtab=true", function()
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(bufnr)
+  vim.api.nvim_buf_set_option(bufnr, "expandtab", true)
+  vim.api.nvim_buf_set_option(bufnr, "shiftwidth", 2)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "" })
+  formatter.indent_posting_line(1)
+  local line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+  test_assert(line == "  ", "expected 2 spaces, got: " .. vim.inspect(line))
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+print("\nTest Summary:")
+print("Tests run: " .. tests_run)
+print("Tests passed: " .. tests_passed)
+print("Tests failed: " .. (tests_run - tests_passed))
+
+if tests_passed == tests_run then
+  print("\n✓ All tests passed!\n")
+  os.exit(0)
+else
+  print("\n✗ Some tests failed!\n")
+  os.exit(1)
+end

--- a/tests/formatter_test.lua
+++ b/tests/formatter_test.lua
@@ -37,7 +37,9 @@ run_test("indent_posting_line uses tab when expandtab=false", function()
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "" })
   formatter.indent_posting_line(1)
   local line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+  local col = vim.fn.col(".")
   test_assert(line == "\t", "expected tab character, got: " .. vim.inspect(line))
+  test_assert(col == #line, "expected cursor at end of indent, got: " .. tostring(col))
   vim.api.nvim_buf_delete(bufnr, { force = true })
 end)
 
@@ -50,7 +52,9 @@ run_test("indent_posting_line uses spaces when expandtab=true", function()
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "" })
   formatter.indent_posting_line(1)
   local line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+  local col = vim.fn.col(".")
   test_assert(line == "    ", "expected 4 spaces, got: " .. vim.inspect(line))
+  test_assert(col == #line, "expected cursor at end of indent, got: " .. tostring(col))
   vim.api.nvim_buf_delete(bufnr, { force = true })
 end)
 
@@ -63,7 +67,9 @@ run_test("indent_posting_line uses 2 spaces when shiftwidth=2 and expandtab=true
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "" })
   formatter.indent_posting_line(1)
   local line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+  local col = vim.fn.col(".")
   test_assert(line == "  ", "expected 2 spaces, got: " .. vim.inspect(line))
+  test_assert(col == #line, "expected cursor at end of indent, got: " .. tostring(col))
   vim.api.nvim_buf_delete(bufnr, { force = true })
 end)
 

--- a/tests/indentation_test.lua
+++ b/tests/indentation_test.lua
@@ -1,11 +1,10 @@
--- Comprehensive functional tests for beancount indentation settings
--- Tests indentation configuration in ftplugin
+-- Tests for beancount ftplugin indentation behavior
+-- Verifies that the plugin does NOT override user indentation settings
 
--- Add lua path to find beancount modules
 ---@diagnostic disable-next-line: redundant-parameter
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
-print("Running comprehensive indentation tests...")
+print("Running indentation tests...")
 
 local function test_assert(condition, message)
   if not condition then
@@ -13,7 +12,6 @@ local function test_assert(condition, message)
   end
 end
 
--- Test counter
 local tests_run = 0
 local tests_passed = 0
 
@@ -28,96 +26,59 @@ local function run_test(name, test_fn)
   end
 end
 
--- Test buffer options after loading ftplugin
-run_test("should set shiftwidth to 4", function()
-  -- Create a new buffer and set it as current
+-- Verify ftplugin preserves user shiftwidth
+run_test("should not override user shiftwidth=2", function()
   local bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_set_current_buf(bufnr)
-  vim.api.nvim_buf_set_option(bufnr, "filetype", "beancount")
-
-  -- Source the ftplugin directly
+  vim.api.nvim_buf_set_option(bufnr, "shiftwidth", 2)
+  vim.b.did_ftplugin = nil
   vim.cmd("source ftplugin/beancount.lua")
-
-  -- Check that shiftwidth is set to 4
-  test_assert(vim.api.nvim_buf_get_option(bufnr, "shiftwidth") == 4, "shiftwidth should be 4")
-
-  -- Clean up
+  test_assert(vim.api.nvim_buf_get_option(bufnr, "shiftwidth") == 2, "shiftwidth should remain 2")
   vim.api.nvim_buf_delete(bufnr, { force = true })
 end)
 
-run_test("should set tabstop to 4", function()
-  -- Create a new buffer and set it as current
+-- Verify ftplugin preserves user tabstop
+run_test("should not override user tabstop=2", function()
   local bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_set_current_buf(bufnr)
-  vim.api.nvim_buf_set_option(bufnr, "filetype", "beancount")
-
-  -- Source the ftplugin directly
+  vim.api.nvim_buf_set_option(bufnr, "tabstop", 2)
+  vim.b.did_ftplugin = nil
   vim.cmd("source ftplugin/beancount.lua")
-
-  -- Check that tabstop is set to 4
-  test_assert(vim.api.nvim_buf_get_option(bufnr, "tabstop") == 4, "tabstop should be 4")
-
-  -- Clean up
+  test_assert(vim.api.nvim_buf_get_option(bufnr, "tabstop") == 2, "tabstop should remain 2")
   vim.api.nvim_buf_delete(bufnr, { force = true })
 end)
 
-run_test("should set softtabstop to 4", function()
-  -- Create a new buffer and set it as current
+-- Verify ftplugin preserves user expandtab=false
+run_test("should not override user expandtab=false", function()
   local bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_set_current_buf(bufnr)
-  vim.api.nvim_buf_set_option(bufnr, "filetype", "beancount")
-
-  -- Source the ftplugin directly
+  vim.api.nvim_buf_set_option(bufnr, "expandtab", false)
+  vim.b.did_ftplugin = nil
   vim.cmd("source ftplugin/beancount.lua")
-
-  -- Check that softtabstop is set to 4
-  test_assert(vim.api.nvim_buf_get_option(bufnr, "softtabstop") == 4, "softtabstop should be 4")
-
-  -- Clean up
+  test_assert(vim.api.nvim_buf_get_option(bufnr, "expandtab") == false, "expandtab should remain false")
   vim.api.nvim_buf_delete(bufnr, { force = true })
 end)
 
-run_test("should have expandtab enabled", function()
-  -- Create a new buffer and set it as current
+-- Verify ftplugin still sets commentstring correctly
+run_test("should set commentstring to ';; %s'", function()
   local bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_set_current_buf(bufnr)
-  vim.api.nvim_buf_set_option(bufnr, "filetype", "beancount")
-
-  -- Source the ftplugin directly
+  vim.b.did_ftplugin = nil
   vim.cmd("source ftplugin/beancount.lua")
-
-  -- Check that expandtab is enabled
-  test_assert(vim.api.nvim_buf_get_option(bufnr, "expandtab") == true, "expandtab should be true")
-
-  -- Clean up
+  test_assert(vim.api.nvim_buf_get_option(bufnr, "commentstring") == ";; %s", "commentstring should be ';; %s'")
   vim.api.nvim_buf_delete(bufnr, { force = true })
 end)
 
-run_test("should handle multiple buffer setups correctly", function()
-  -- Create and setup first buffer
-  local bufnr1 = vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_set_current_buf(bufnr1)
-  vim.api.nvim_buf_set_option(bufnr1, "filetype", "beancount")
+-- Verify ftplugin still sets foldmethod correctly
+run_test("should set foldmethod to 'expr'", function()
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(bufnr)
+  vim.b.did_ftplugin = nil
   vim.cmd("source ftplugin/beancount.lua")
-
-  -- Create and setup second buffer
-  local bufnr2 = vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_set_current_buf(bufnr2)
-  vim.api.nvim_buf_set_option(bufnr2, "filetype", "beancount")
-  vim.cmd("source ftplugin/beancount.lua")
-
-  -- Check both buffers have correct settings
-  test_assert(vim.api.nvim_buf_get_option(bufnr1, "shiftwidth") == 4, "buffer1 shiftwidth should be 4")
-  test_assert(vim.api.nvim_buf_get_option(bufnr2, "shiftwidth") == 4, "buffer2 shiftwidth should be 4")
-  test_assert(vim.api.nvim_buf_get_option(bufnr1, "tabstop") == 4, "buffer1 tabstop should be 4")
-  test_assert(vim.api.nvim_buf_get_option(bufnr2, "tabstop") == 4, "buffer2 tabstop should be 4")
-
-  -- Clean up
-  vim.api.nvim_buf_delete(bufnr1, { force = true })
-  vim.api.nvim_buf_delete(bufnr2, { force = true })
+  test_assert(vim.wo.foldmethod == "expr", "foldmethod should be 'expr'")
+  vim.api.nvim_buf_delete(bufnr, { force = true })
 end)
 
--- Print test summary
 print("\nTest Summary:")
 print("Tests run: " .. tests_run)
 print("Tests passed: " .. tests_passed)

--- a/tests/indentation_test.lua
+++ b/tests/indentation_test.lua
@@ -48,6 +48,17 @@ run_test("should not override user tabstop=2", function()
   vim.api.nvim_buf_delete(bufnr, { force = true })
 end)
 
+-- Verify ftplugin preserves user softtabstop
+run_test("should not override user softtabstop=2", function()
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(bufnr)
+  vim.api.nvim_buf_set_option(bufnr, "softtabstop", 2)
+  vim.b.did_ftplugin = nil
+  vim.cmd("source ftplugin/beancount.lua")
+  test_assert(vim.api.nvim_buf_get_option(bufnr, "softtabstop") == 2, "softtabstop should remain 2")
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
 -- Verify ftplugin preserves user expandtab=false
 run_test("should not override user expandtab=false", function()
   local bufnr = vim.api.nvim_create_buf(false, true)


### PR DESCRIPTION
## Summary

- Remove hardcoded `expandtab=true`, `shiftwidth=4`, `tabstop=4`, `softtabstop=4` from `ftplugin/beancount.lua`
- Use `vim.fn.shiftwidth()` in `formatter.lua` instead of `vim.bo.tabstop` for idiomatic indent width resolution
- Rewrite `indentation_test.lua` to verify the plugin does **not** override user settings
- Add `indentation_test.lua` to the `Makefile` test target

## Motivation

The ftplugin was overriding user `.editorconfig` settings (which are evaluated before ftplugin runs). Beancount's own examples use 2-space indentation, so 4-space is a personal preference. Standard Neovim plugin practice is to leave indentation to the user.

Users who want 4-space indentation can set it via `.editorconfig`, `after/ftplugin/beancount.lua`, or an `autocmd FileType beancount` in their config.

Closes #7

## Test plan

- [x] `make test` passes (all Lua tests green)
- [x] `make lint` passes (0 warnings/errors)
- [x] Open a `.beancount` file and confirm `tabstop`/`shiftwidth` are not forced to 4