### PR TITLE
feat(fold): add fold-marker support to fold expression

### DIFF
--- a/lua/beancount/fold.lua
+++ b/lua/beancount/fold.lua
@@ -3,14 +3,30 @@
 -- Groups transactions, directives, and other logical blocks
 local M = {}
 
--- Buffer-local cache for marker nesting levels, keyed on (bufnr, changedtick)
-local marker_cache = { bufnr = -1, tick = -1, levels = {} }
+-- Marker nesting cache keyed by buffer, with changedtick invalidation.
+local marker_cache = {}
 
-local function update_marker_cache()
-  local bufnr = vim.api.nvim_get_current_buf()
+local function apply_open_marker(current_level, marker_num)
+  local n = tonumber(marker_num)
+  if n then
+    return n
+  end
+  return current_level + 1
+end
+
+local function apply_close_marker(current_level, marker_num)
+  local n = tonumber(marker_num)
+  if n then
+    return n - 1
+  end
+  return math.max(0, current_level - 1)
+end
+
+local function update_marker_cache(bufnr)
   local tick = vim.api.nvim_buf_get_changedtick(bufnr)
-  if marker_cache.bufnr == bufnr and marker_cache.tick == tick then
-    return
+  local cached = marker_cache[bufnr]
+  if cached and cached.tick == tick then
+    return cached.levels
   end
 
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -20,38 +36,42 @@ local function update_marker_cache()
   for i, line in ipairs(lines) do
     local open_num = line:match("{{{(%d*)")
     local close_num = line:match("}}}(%d*)")
+    local open_pos = line:find("{{{", 1, true)
+    local close_pos = line:find("}}}", 1, true)
 
-    if open_num then
-      local n = tonumber(open_num)
-      if n then
-        current_level = n
+    if open_num and close_num then
+      if open_pos < close_pos then
+        current_level = apply_open_marker(current_level, open_num)
+        levels[i] = { marker = nil, level = current_level }
+        current_level = apply_close_marker(current_level, close_num)
       else
-        current_level = current_level + 1
+        levels[i] = { marker = nil, level = current_level }
+        current_level = apply_close_marker(current_level, close_num)
+        current_level = apply_open_marker(current_level, open_num)
       end
+    elseif open_num then
+      current_level = apply_open_marker(current_level, open_num)
       levels[i] = { marker = "open", level = current_level }
     elseif close_num then
-      local n = tonumber(close_num)
       levels[i] = { marker = "close", level = current_level }
-      if n then
-        current_level = n - 1
-      else
-        current_level = math.max(0, current_level - 1)
-      end
+      current_level = apply_close_marker(current_level, close_num)
     else
       levels[i] = { marker = nil, level = current_level }
     end
   end
 
-  marker_cache = { bufnr = bufnr, tick = tick, levels = levels }
+  marker_cache[bufnr] = { tick = tick, levels = levels }
+  return levels
 end
 
 -- Main folding expression function for beancount syntax
 -- @return string: Fold level indicator for current line
 M.foldexpr = function()
-  update_marker_cache()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local levels = update_marker_cache(bufnr)
 
   local lnum = vim.v.lnum
-  local info = marker_cache.levels[lnum] or { marker = nil, level = 0 }
+  local info = levels[lnum] or { marker = nil, level = 0 }
   local base = info.level
 
   -- Handle fold marker open/close lines

--- a/lua/beancount/fold.lua
+++ b/lua/beancount/fold.lua
@@ -3,14 +3,69 @@
 -- Groups transactions, directives, and other logical blocks
 local M = {}
 
+-- Buffer-local cache for marker nesting levels, keyed on (bufnr, changedtick)
+local marker_cache = { bufnr = -1, tick = -1, levels = {} }
+
+local function update_marker_cache()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local tick = vim.api.nvim_buf_get_changedtick(bufnr)
+  if marker_cache.bufnr == bufnr and marker_cache.tick == tick then
+    return
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local levels = {}
+  local current_level = 0
+
+  for i, line in ipairs(lines) do
+    local open_num = line:match("{{{(%d*)")
+    local close_num = line:match("}}}(%d*)")
+
+    if open_num then
+      local n = tonumber(open_num)
+      if n then
+        current_level = n
+      else
+        current_level = current_level + 1
+      end
+      levels[i] = { marker = "open", level = current_level }
+    elseif close_num then
+      local n = tonumber(close_num)
+      levels[i] = { marker = "close", level = current_level }
+      if n then
+        current_level = n - 1
+      else
+        current_level = math.max(0, current_level - 1)
+      end
+    else
+      levels[i] = { marker = nil, level = current_level }
+    end
+  end
+
+  marker_cache = { bufnr = bufnr, tick = tick, levels = levels }
+end
+
 -- Main folding expression function for beancount syntax
 -- @return string: Fold level indicator for current line
 M.foldexpr = function()
-  local line = vim.fn.getline(vim.v.lnum)
+  update_marker_cache()
+
+  local lnum = vim.v.lnum
+  local info = marker_cache.levels[lnum] or { marker = nil, level = 0 }
+  local base = info.level
+
+  -- Handle fold marker open/close lines
+  if info.marker == "open" then
+    return ">" .. base
+  elseif info.marker == "close" then
+    return "<" .. base
+  end
+
+  local line = vim.fn.getline(lnum)
 
   -- Start new fold at transaction lines (YYYY-MM-DD * or !)
   if line:match("^%d%d%d%d%-%d%d%-%d%d%s+[*!]") then
-    return ">1"
+    return ">" .. (base + 1)
   end
 
   -- Major beancount directives each get their own fold
@@ -37,17 +92,17 @@ M.foldexpr = function()
       or line:match("^%d%d%d%d%-%d%d%-%d%d%s+custom$")
       or line:match("^%d%d%d%d%-%d%d%-%d%d%s+price$")
   then
-    return ">1"
+    return ">" .. (base + 1)
   end
 
   -- Configuration directives (plugins, options, includes) start folds
   if line:match("^plugin") or line:match("^option") or line:match("^include") then
-    return ">1"
+    return ">" .. (base + 1)
   end
 
-  -- Empty lines close the current fold level
+  -- Empty lines: return marker level (or "0" if outside markers)
   if line:match("^%s*$") then
-    return "0"
+    return tostring(base)
   end
 
   -- Posting lines and metadata continue the current fold

--- a/tests/autofill_test.lua
+++ b/tests/autofill_test.lua
@@ -402,7 +402,8 @@ run_test("should parse new JSON structure with cost_basis field", function()
     test_assert(autofill.automatics["/test/file.beancount"] ~= nil, "Should parse automatics")
     test_assert(autofill.automatics["/test/file.beancount"]["10"][1] == "-100.00 USD", "Should parse automatics data")
     test_assert(autofill.cost_basis_data["/test/file.beancount"] ~= nil, "Should parse cost_basis")
-    test_assert(autofill.cost_basis_data["/test/file.beancount"]["5"] == "100.00 AAPL {150.00 USD, 2025-10-12} @@ 15000.0000 USD", "Should parse cost_basis data")
+    local expected_cost = "100.00 AAPL {150.00 USD, 2025-10-12} @@ 15000.0000 USD"
+    test_assert(autofill.cost_basis_data["/test/file.beancount"]["5"] == expected_cost, "Should parse cost_basis data")
 end)
 
 -- Test 9: update_data() should handle backward compatibility with old format

--- a/tests/fold_test.lua
+++ b/tests/fold_test.lua
@@ -1266,6 +1266,80 @@ run_test("should handle explicitly numbered nested markers {{{1 and {{{2", funct
   restore_all_mocks()
 end)
 
+-- Test 55: Marker cache should be per-buffer, not globally single-entry
+run_test("should cache marker levels independently per buffer", function()
+  local fold = get_fold()
+  local buffers = {
+    [1001] = {
+      tick = 1,
+      lines = {
+        "; a {{{",
+        "",
+        "; }}}",
+      },
+    },
+    [1002] = {
+      tick = 1,
+      lines = {
+        "; b {{{",
+        "",
+        "; }}}",
+      },
+    },
+  }
+
+  local current_buf = 1001
+  local scan_calls = { [1001] = 0, [1002] = 0 }
+
+  vim.api.nvim_get_current_buf = function() return current_buf end
+  vim.api.nvim_buf_get_changedtick = function(bufnr) return buffers[bufnr].tick end
+  vim.api.nvim_buf_get_lines = function(bufnr, s, e, _)
+    if s == 0 and e == -1 then
+      scan_calls[bufnr] = scan_calls[bufnr] + 1
+      return buffers[bufnr].lines
+    end
+    return {}
+  end
+  vim.fn.getline = function(_) return buffers[current_buf].lines[vim.v.lnum] or "" end
+
+  for _ = 1, 4 do
+    current_buf = 1001
+    vim.v.lnum = 2
+    fold.foldexpr()
+
+    current_buf = 1002
+    vim.v.lnum = 2
+    fold.foldexpr()
+  end
+
+  test_assert(scan_calls[1001] == 1, "buffer 1001 should be scanned once when unchanged")
+  test_assert(scan_calls[1002] == 1, "buffer 1002 should be scanned once when unchanged")
+
+  current_buf = 1001
+  buffers[1001].tick = 2
+  vim.v.lnum = 2
+  fold.foldexpr()
+  test_assert(scan_calls[1001] == 2, "buffer 1001 should rescan after changedtick update")
+  test_assert(scan_calls[1002] == 1, "buffer 1002 should keep cached levels when unchanged")
+
+  restore_all_mocks()
+end)
+
+-- Test 56: Lines containing both open+close markers should not leak level
+run_test("should not leak marker depth for lines containing both {{{ and }}}", function()
+  local fold = get_fold()
+  local lines = {
+    "; inline {{{ }}}",
+    '2025-01-01 * "txn"',
+  }
+
+  mock_buffer(lines, 1)
+  fold.foldexpr()
+  set_lnum(lines, 2)
+  test_assert(fold.foldexpr() == ">1", "transaction after inline open+close markers should stay at base level 0")
+  restore_all_mocks()
+end)
+
 -- Print summary
 print("\nTest Summary:")
 print("Tests run: " .. tests_run)

--- a/tests/fold_test.lua
+++ b/tests/fold_test.lua
@@ -53,6 +53,37 @@ local function restore_vim_functions()
   vim.v.lnum = original_v_lnum
 end
 
+-- Mock vim.api buffer functions for marker tests
+local original_nvim_get_current_buf = vim.api.nvim_get_current_buf
+local original_nvim_buf_get_changedtick = vim.api.nvim_buf_get_changedtick
+local original_nvim_buf_get_lines = vim.api.nvim_buf_get_lines
+local mock_tick_counter = 0
+
+local function mock_buffer(lines, lnum)
+  mock_tick_counter = mock_tick_counter + 1
+  local current_tick = mock_tick_counter
+  vim.api.nvim_get_current_buf = function() return 999 end
+  vim.api.nvim_buf_get_changedtick = function(_) return current_tick end
+  vim.api.nvim_buf_get_lines = function(_, s, e, _)
+    if s == 0 and e == -1 then return lines end
+    return {}
+  end
+  vim.fn.getline = function(_) return lines[lnum] or "" end
+  vim.v.lnum = lnum
+end
+
+local function set_lnum(lines, lnum)
+  vim.fn.getline = function(_) return lines[lnum] or "" end
+  vim.v.lnum = lnum
+end
+
+local function restore_all_mocks()
+  vim.api.nvim_get_current_buf = original_nvim_get_current_buf
+  vim.api.nvim_buf_get_changedtick = original_nvim_buf_get_changedtick
+  vim.api.nvim_buf_get_lines = original_nvim_buf_get_lines
+  restore_vim_functions()
+end
+
 -- Test 1: Basic module loading
 run_test("should load fold module", function()
   local fold = get_fold()
@@ -1082,6 +1113,157 @@ run_test("should maintain proper state isolation", function()
   test_assert(result1 == result2 and result2 == result3, "multiple calls should return consistent results")
 
   restore_vim_functions()
+end)
+
+-- Test 47: Basic fold marker open/close detection
+run_test("should detect basic {{{ and }}} markers", function()
+  local fold = get_fold()
+  local lines = {
+    "; Section {{{",
+    '2025-01-01 * "transaction"',
+    "  Assets:One  400.00 USD",
+    "",
+    "; }}}",
+  }
+  mock_buffer(lines, 1)
+  test_assert(fold.foldexpr() == ">1", "open marker should return '>1'")
+  set_lnum(lines, 5)
+  test_assert(fold.foldexpr() == "<1", "close marker should return '<1'")
+  restore_all_mocks()
+end)
+
+-- Test 48: Numbered markers {{{2 and }}}2
+run_test("should handle numbered markers {{{2 and }}}2", function()
+  local fold = get_fold()
+  local lines = {
+    "; {{{2",
+    "",
+    "; }}}2",
+  }
+  mock_buffer(lines, 1)
+  test_assert(fold.foldexpr() == ">2", "numbered open marker {{{2 should return '>2'")
+  set_lnum(lines, 3)
+  test_assert(fold.foldexpr() == "<2", "numbered close marker }}}2 should return '<2'")
+  restore_all_mocks()
+end)
+
+-- Test 49: Blank lines inside markers return marker level (not "0")
+run_test("should return marker level for blank lines inside markers", function()
+  local fold = get_fold()
+  local lines = {
+    "; outer {{{",
+    "",
+    "; }}}",
+  }
+  mock_buffer(lines, 2)
+  test_assert(fold.foldexpr() == "1", "blank line inside level-1 marker should return '1' not '0'")
+  restore_all_mocks()
+end)
+
+-- Test 50: Transactions inside markers return marker_level + 1
+run_test("should return marker_level+1 for transactions inside markers", function()
+  local fold = get_fold()
+  local lines = {
+    "; {{{",
+    '2025-01-01 * "transaction"',
+    "  Assets:One  400.00 USD",
+    "  Assets:Two",
+    "; }}}",
+  }
+  mock_buffer(lines, 2)
+  test_assert(fold.foldexpr() == ">2", "transaction inside marker should return '>2'")
+  set_lnum(lines, 3)
+  test_assert(fold.foldexpr() == "=", "posting inside marker should still return '='")
+  restore_all_mocks()
+end)
+
+-- Test 51: Nested markers
+run_test("should handle nested {{{ markers correctly", function()
+  local fold = get_fold()
+  local lines = {
+    "; outer {{{",
+    "; inner {{{",
+    "",
+    "; inner }}}",
+    "",
+    "; outer }}}",
+  }
+  mock_buffer(lines, 1)
+  test_assert(fold.foldexpr() == ">1", "outer open marker should return '>1'")
+  set_lnum(lines, 2)
+  test_assert(fold.foldexpr() == ">2", "inner open marker should return '>2'")
+  set_lnum(lines, 3)
+  test_assert(fold.foldexpr() == "2", "blank inside inner marker should return '2'")
+  set_lnum(lines, 4)
+  test_assert(fold.foldexpr() == "<2", "inner close marker should return '<2'")
+  set_lnum(lines, 5)
+  test_assert(fold.foldexpr() == "1", "blank inside outer marker (after inner close) should return '1'")
+  set_lnum(lines, 6)
+  test_assert(fold.foldexpr() == "<1", "outer close marker should return '<1'")
+  restore_all_mocks()
+end)
+
+-- Test 52: No markers - regression test for unchanged behavior
+run_test("should preserve existing behavior when no markers present", function()
+  local fold = get_fold()
+  local lines = {
+    '2025-01-01 * "transaction"',
+    "  Assets:One  400.00 USD",
+    "",
+    "2025-01-01 open Assets:Checking",
+    "",
+  }
+  mock_buffer(lines, 1)
+  test_assert(fold.foldexpr() == ">1", "transaction with no markers should return '>1'")
+  set_lnum(lines, 2)
+  test_assert(fold.foldexpr() == "=", "posting with no markers should return '='")
+  set_lnum(lines, 3)
+  test_assert(fold.foldexpr() == "0", "blank line with no markers should return '0'")
+  set_lnum(lines, 4)
+  test_assert(fold.foldexpr() == ">1", "directive with no markers should return '>1'")
+  restore_all_mocks()
+end)
+
+-- Test 53: Markers embedded in comment lines (common beancount pattern)
+run_test("should handle markers embedded in comment lines", function()
+  local fold = get_fold()
+  local lines = {
+    "; Account One {{{",
+    '2025-01-01 * "transaction"',
+    "  Assets:One  400.00 USD",
+    "; }}}",
+  }
+  mock_buffer(lines, 1)
+  test_assert(fold.foldexpr() == ">1", "comment line with {{{ should return '>1'")
+  set_lnum(lines, 4)
+  test_assert(fold.foldexpr() == "<1", "comment line with }}} should return '<1'")
+  restore_all_mocks()
+end)
+
+-- Test 54: Explicitly numbered nested markers {{{1 / {{{2
+run_test("should handle explicitly numbered nested markers {{{1 and {{{2", function()
+  local fold = get_fold()
+  local lines = {
+    "; level1 {{{1",
+    "; level2 {{{2",
+    "",
+    "; end level2 }}}2",
+    "",
+    "; end level1 }}}1",
+  }
+  mock_buffer(lines, 1)
+  test_assert(fold.foldexpr() == ">1", "{{{1 should return '>1'")
+  set_lnum(lines, 2)
+  test_assert(fold.foldexpr() == ">2", "{{{2 should return '>2'")
+  set_lnum(lines, 3)
+  test_assert(fold.foldexpr() == "2", "blank inside {{{2 region should return '2'")
+  set_lnum(lines, 4)
+  test_assert(fold.foldexpr() == "<2", "}}}2 should return '<2'")
+  set_lnum(lines, 5)
+  test_assert(fold.foldexpr() == "1", "blank inside {{{1 region (after }}}2) should return '1'")
+  set_lnum(lines, 6)
+  test_assert(fold.foldexpr() == "<1", "}}}1 should return '<1'")
+  restore_all_mocks()
 end)
 
 -- Print summary


### PR DESCRIPTION
## Summary

- Extends the beancount fold expression to support Vim's default fold-markers (`{{{` / `}}}`)
- Marker-defined folds nest correctly with the existing transaction/directive folds (markers act as a base level, and content folds stack on top)
- Buffer-local caching keyed on `changedtick` avoids rescanning the full buffer on every fold evaluation call

## Test plan

- [x] Open a `.beancount` file and add `; {{{` / `; }}}` comment markers around sections — verify they fold independently
- [x] Verify numbered markers (`{{{1`, `{{{2`) set absolute nesting levels correctly
- [x] Verify transactions and directives inside a marker section still fold at the expected relative depth
- [x] Verify files with no markers behave identically to before this change

Closes #6