### PR TITLE
Refactor path resolution and improve robustness across modules

### DIFF
--- a/lua/beancount/diagnostics.lua
+++ b/lua/beancount/diagnostics.lua
@@ -15,6 +15,25 @@ M.setup = function()
   -- No global initialization needed
 end
 
+-- Resolve the configured Python executable path, expanding ~ and env vars.
+-- @return string: Resolved python path ready for use in jobstart
+local function resolve_python_path()
+  local python_path = config.get("python_path")
+
+  -- Handle Windows-style environment variable expansion (e.g., %PYTHON_HOME%)
+  if python_path:match("^%%") then
+    python_path = utils.resolve_env_vars(python_path)
+  end
+
+  -- Expand ~ to user home directory
+  if python_path:sub(1, 1) == "~" then
+    local home = os.getenv("HOME") or os.getenv("USERPROFILE") or ""
+    python_path = home .. python_path:sub(2)
+  end
+
+  return python_path
+end
+
 -- Run beancount validation on the main beancount file
 -- Executes the external Python script to validate syntax and generate completions
 M.check_file = function()
@@ -25,17 +44,7 @@ M.check_file = function()
 
   local plugin_dir = utils.get_plugin_dir()
   local check_script = plugin_dir .. "/pythonFiles/beancheck.py"
-  local python_path = config.get("python_path")
-
-  -- Handle environment variable expansion in python_path (e.g., %PYTHON_HOME%)
-  if python_path:match("^%%") then
-    python_path = utils.resolve_env_vars(python_path)
-  end
-
-  -- Expand ~ to user home directory in python_path
-  if python_path:sub(1, 1) == "~" then
-    python_path = os.getenv("HOME") .. python_path:sub(2)
-  end
+  local python_path = resolve_python_path()
 
   local args = { check_script, main_file }
   if config.get("complete_payee_narration") then
@@ -62,17 +71,7 @@ M.check_file_sync = function()
 
   local plugin_dir = utils.get_plugin_dir()
   local check_script = plugin_dir .. "/pythonFiles/beancheck.py"
-  local python_path = config.get("python_path")
-
-  -- Handle environment variable expansion in python_path (e.g., %PYTHON_HOME%)
-  if python_path:match("^%%") then
-    python_path = utils.resolve_env_vars(python_path)
-  end
-
-  -- Expand ~ to user home directory in python_path
-  if python_path:sub(1, 1) == "~" then
-    python_path = os.getenv("HOME") .. python_path:sub(2)
-  end
+  local python_path = resolve_python_path()
 
   local args = { check_script, main_file }
   if config.get("complete_payee_narration") then

--- a/lua/beancount/formatter.lua
+++ b/lua/beancount/formatter.lua
@@ -224,21 +224,38 @@ M.format_posting_line = function(line_num, separator_col)
   end
 end
 
+-- Cached result of utf8 module availability check
+local _utf8_mod = nil
+local _utf8_checked = false
+
 -- Calculate display width, considering CJK characters if configured
 M.display_width = function(text)
   if config.get("fixed_cjk_width") then
-    local width = 0
-    for _, char in require("utf8").codes(text) do
-      if M.is_cjk_char(char) then
-        width = width + 2
+    if not _utf8_checked then
+      _utf8_checked = true
+      local ok, mod = pcall(require, "utf8")
+      if ok then
+        _utf8_mod = mod
       else
-        width = width + 1
+        vim.notify(
+          "beancount.nvim: fixed_cjk_width requires a Lua runtime with the 'utf8' module (Lua 5.3+). Falling back to strdisplaywidth.",
+          vim.log.levels.WARN
+        )
       end
     end
-    return width
-  else
-    return vim.fn.strdisplaywidth(text)
+    if _utf8_mod then
+      local width = 0
+      for _, char in _utf8_mod.codes(text) do
+        if M.is_cjk_char(char) then
+          width = width + 2
+        else
+          width = width + 1
+        end
+      end
+      return width
+    end
   end
+  return vim.fn.strdisplaywidth(text)
 end
 
 -- Check if character is CJK (Chinese, Japanese, Korean)
@@ -256,22 +273,13 @@ M.format_buffer = function()
   local line_count = vim.fn.line("$")
   local separator_col = config.get("separator_column")
 
-  -- Debug: track how many lines we're formatting
-  local formatted_lines = 0
-
   for line_num = 1, line_count do
     local line = vim.fn.getline(line_num)
 
     -- Format posting lines within transactions
     if M.is_posting_line(line) then
       M.format_posting_line(line_num, separator_col)
-      formatted_lines = formatted_lines + 1
     end
-  end
-
-  -- Debug: uncomment to see formatting activity
-  if formatted_lines == 0 then
-    vim.notify("No posting lines found to format", vim.log.levels.WARN)
   end
 end
 

--- a/lua/beancount/navigation.lua
+++ b/lua/beancount/navigation.lua
@@ -40,15 +40,19 @@ M.goto_account_definition = function(account)
     return
   end
 
-  -- If not found locally, search all beancount files in project
-  local files = vim.fn.glob("**/*.beancount", false, true)
-  vim.list_extend(files, vim.fn.glob("**/*.bean", false, true))
+  -- If not found locally, search all beancount files under the main file's directory
+  local utils = require("beancount.utils")
+  local main_file = utils.get_main_bean_file()
+  local search_dir = main_file ~= "" and vim.fn.fnamemodify(main_file, ":h") or vim.fn.getcwd()
+
+  local files = vim.fn.glob(search_dir .. "/**/*.beancount", false, true)
+  vim.list_extend(files, vim.fn.glob(search_dir .. "/**/*.bean", false, true))
 
   for _, file in ipairs(files) do
     local lines = vim.fn.readfile(file)
     for i, line in ipairs(lines) do
       if line:match("^%d%d%d%d%-%d%d%-%d%d%s+open%s+" .. vim.fn.escape(account, "\\.*[]^$(){}+?|")) then
-        pcall(vim.cmd, "edit " .. file)
+        pcall(vim.cmd, "edit " .. vim.fn.fnameescape(file))
         vim.fn.cursor(i, 1)
         pcall(vim.cmd, "normal! zz")
         return
@@ -82,9 +86,9 @@ M.open_include_file = function(filename)
   local full_path = current_dir .. "/" .. filename
 
   if vim.fn.filereadable(full_path) == 1 then
-    pcall(vim.cmd, "edit " .. full_path)
+    pcall(vim.cmd, "edit " .. vim.fn.fnameescape(full_path))
   elseif vim.fn.filereadable(filename) == 1 then
-    pcall(vim.cmd, "edit " .. filename)
+    pcall(vim.cmd, "edit " .. vim.fn.fnameescape(filename))
   else
     vim.notify("Include file not found: " .. filename, vim.log.levels.WARN)
   end


### PR DESCRIPTION
## Summary
This PR refactors and improves code robustness across three modules by extracting common logic, adding graceful fallbacks, and fixing path handling issues.

## Key Changes

**diagnostics.lua:**
- Extracted Python path resolution logic into a new `resolve_python_path()` function to eliminate code duplication
- The function handles environment variable expansion and tilde expansion consistently
- Applied to both `check_file()` and `check_file_sync()` functions

**formatter.lua:**
- Added graceful fallback for the `utf8` module with a cached availability check
- When `fixed_cjk_width` is enabled but the `utf8` module is unavailable (Lua < 5.3), the code now falls back to `vim.fn.strdisplaywidth()` with a warning instead of crashing
- Removed debug code that tracked formatted lines and displayed unnecessary warnings
- Improved code flow by consolidating the width calculation logic

**navigation.lua:**
- Fixed `goto_account_definition()` to search within the main beancount file's directory instead of the entire project root, improving search performance and accuracy
- Added proper file path escaping using `vim.fn.fnameescape()` in three locations to handle filenames with special characters
- Added missing `utils` module import for accessing `get_main_bean_file()`

## Notable Implementation Details
- The Python path resolution now properly handles both Windows (`%VAR%`) and Unix (`~`) style paths
- The utf8 module check is performed once and cached to avoid repeated `pcall` overhead
- File path escaping prevents issues with spaces and special characters in filenames

https://claude.ai/code/session_019cRxw45vfZbmVrNNik7AA4